### PR TITLE
Implement a global and shared rand.Rand object

### DIFF
--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -2,6 +2,7 @@ package entropy
 
 import (
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -41,10 +42,10 @@ func Test_RandStr(t *testing.T) {
 	for n := 0; n != 500; n++ {
 		zero := RandStr(55)
 		one := RandStr(55)
-		t.Logf("Random0: %s Random1: %s", zero, one)
+		// t.Logf("Random0: %s Random1: %s", zero, one)
 		randStrChecks(zero, one, t)
 	}
-
+	t.Logf("[SUCCESS] RandStr had no collisions")
 }
 
 func Test_RandStr_Entropy(t *testing.T) {
@@ -67,10 +68,10 @@ func Test_RandStr_Entropy(t *testing.T) {
 			t.Errorf("[ENTROPY FAILURE] more than a quarter of the string is the same!\n zero: %s \n one: %s \nTotal similar: %d",
 				zero, one, similarity)
 		}
-		t.Logf("[ENTROPY] Similarity score (lower is better): %d", similarity)
+		// t.Logf("[ENTROPY] Similarity score (lower is better): %d", similarity)
 		totalScore += similarity
 	}
-	t.Logf("[ENTROPY] final score (lower is better): %d", totalScore)
+	t.Logf("[ENTROPY] final score (lower is better): %d (RandStr)", totalScore)
 }
 
 func Test_RandomStrChoice(t *testing.T) {
@@ -82,4 +83,41 @@ func Test_RandomStrChoice(t *testing.T) {
 		slice = append(slice, RandStr(555))
 	}
 	check(RandomStrChoice(slice), RandomStrChoice(slice), t)
+}
+
+func Test_RNGUint32(t *testing.T) {
+	// start globals fresh, just for coverage.
+	sharedRand = GetOptimizedRand()
+	getSharedRand = &sync.Once{}
+	RNGUint32()
+}
+
+func Benchmark_RandStr5(b *testing.B) {
+	for n := 0; n != b.N; n++ {
+		RandStr(5)
+	}
+}
+
+func Benchmark_RandStr25(b *testing.B) {
+	for n := 0; n != b.N; n++ {
+		RandStr(25)
+	}
+}
+
+func Benchmark_RandStr55(b *testing.B) {
+	for n := 0; n != b.N; n++ {
+		RandStr(55)
+	}
+}
+
+func Benchmark_RandStr500(b *testing.B) {
+	for n := 0; n != b.N; n++ {
+		RandStr(500)
+	}
+}
+
+func Benchmark_RandStr55555(b *testing.B) {
+	for n := 0; n != b.N; n++ {
+		RandStr(55555)
+	}
 }


### PR DESCRIPTION
Entropy scoring test based largely from existing unit tests:
```golang
package main

import (
	"fmt"
	"log"
	"os"
	"strings"

	"git.tcp.direct/kayos/common/entropy"
)

var (
	RandScore     = 0
	FastRandScore = 0
)

func RandStr_Entropy(fast bool) {
	var rstr func(n int) string
	rstr = entropy.RandStr
	if fast {
		rstr = entropy.FastRandStr
	}
	var totalScore = 0
	for n := 0; n != 500; n++ {
		zero := rstr(55)
		one := rstr(55)
		zeroSplit := strings.Split(zero, "")
		oneSplit := strings.Split(one, "")
		var similarity = 0
		for i, char := range zeroSplit {
			if oneSplit[i] != char {
				continue
			}
			similarity++
			// t.Logf("[-] zeroSplit[%d] is the same as oneSplit[%d] (%s)", i, i, char)
		}
		if similarity*4 > 55 {
			log.Fatalf("[ENTROPY FAILURE] more than a quarter of the string is the same!\n zero: %s \n one: %s \nTotal similar: %d",
				zero, one, similarity)
		}
		// t.Logf("[ENTROPY] Similarity score (lower is better): %d", similarity)
		totalScore += similarity
	}
	if fast {
		FastRandScore = totalScore
	} else {
		RandScore = totalScore
	}
	log.Printf("[ENTROPY] final score (lower is better): %d (fast: %t)", totalScore, fast)
}

var (
	RandScoreTotal     = 0
	FastRandScoreTotal = 0
)

func main() {
	for n := 0; n != 500; n++ {
		RandStr_Entropy(true)
		RandStr_Entropy(false)
		if RandScore > FastRandScore {
			FastRandScoreTotal++
		} else {
			RandScoreTotal++
		}
		FastRandScore = 0
		RandScore = 0
	}
	_, _ = fmt.Fprintf(os.Stdout,
		"\n\n--------\n\nRandScore: %d\nFastRandScore: %d\n\n",
		RandScoreTotal, FastRandScoreTotal)
}

```

## Entropy score difference:

```
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 871 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 850 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 885 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 849 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 867 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 853 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 836 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 869 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 886 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 834 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 859 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 833 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 893 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 864 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 824 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 838 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 879 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 879 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 840 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 883 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 788 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 814 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 866 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 855 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 853 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 863 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 836 (fast: true)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 793 (fast: false)
2022/07/12 01:46:59 [ENTROPY] final score (lower is better): 838 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 971 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 859 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 843 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 858 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 809 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 869 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 865 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 872 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 852 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 857 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 884 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 853 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 880 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 847 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 875 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 948 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 848 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 851 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 848 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 819 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 868 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 889 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 859 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 852 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 830 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 845 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 897 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 785 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 859 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 918 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 869 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 889 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 867 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 845 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 864 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 897 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 839 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 878 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 863 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 801 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 880 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 898 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 830 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 810 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 875 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 815 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 848 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 865 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 864 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 906 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 856 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 851 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 876 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 842 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 860 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 798 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 833 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 858 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 832 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 835 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 900 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 886 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 833 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 877 (fast: true)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 939 (fast: false)
2022/07/12 01:47:00 [ENTROPY] final score (lower is better): 832 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 893 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 872 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 847 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 854 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 877 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 844 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 893 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 829 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 890 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 848 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 860 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 859 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 864 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 810 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 865 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 902 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 884 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 847 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 869 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 847 (fast: true)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 860 (fast: false)
2022/07/12 01:47:01 [ENTROPY] final score (lower is better): 830 (fast: true)
[...]

--------

RandScore: 244
FastRandScore: 256
```

## Performance Gainz

```
goos: linux
goarch: amd64
pkg: git.tcp.direct/kayos/common/entropy
cpu: AMD Ryzen 9 5900X 12-Core Processor
Benchmark_FastRandStr5-24        	16634295	   70.54 ns/op
Benchmark_FastRandStr25-24       	4750281	      251.4 ns/op
Benchmark_FastRandStr55-24       	2358594	      498.9 ns/op
Benchmark_FastRandStr500-24      	 270087	     4173 ns/op
Benchmark_FastRandStr55555-24    	   2541	   466373 ns/op
Benchmark_RandStr5-24            	 430225	     2686 ns/op
Benchmark_RandStr25-24           	  91171	    13381 ns/op
Benchmark_RandStr55-24           	  41107	    29162 ns/op
Benchmark_RandStr500-24          	   4519	   267191 ns/op
Benchmark_RandStr55555-24        	     39	 29355739 ns/op
```

---

I think the choice is clear, instead of maintaining two different versions (fastrand and rand), I'm just going to implement the global shared rand as the main entropy interface.