### PR TITLE
entropy: fix race condition, massive performance boost

### DIFF
--- a/entropy/entropy.go
+++ b/entropy/entropy.go
@@ -52,6 +52,7 @@ func AcquireRand() *rand.Rand {
 
 func ReleaseRand(r *rand.Rand) {
 	lolXD.Put(r)
+	r = nil
 }
 
 // RandomStrChoice returns a random item from an input slice of strings.

--- a/entropy/entropy.go
+++ b/entropy/entropy.go
@@ -8,12 +8,51 @@ import (
 	"time"
 
 	"nullprogram.com/x/rng"
+
+	"git.tcp.direct/kayos/common/pool"
 )
 
+type randPool struct {
+	sync.Pool
+}
+
+func (p *randPool) Get() *rand.Rand {
+	return p.Pool.Get().(*rand.Rand)
+}
+
+func (p *randPool) Put(r *rand.Rand) {
+	p.Pool.Put(r)
+}
+
 var (
+	lolXD = randPool{
+		Pool: sync.Pool{
+			New: func() interface{} {
+				sm64 := new(rng.SplitMix64)
+				sm64.Seed(GetCryptoSeed())
+				prng := rand.New(sm64) //nolint:gosec
+				return prng
+			},
+		},
+	}
+	hardLocc      = &sync.Mutex{}
 	sharedRand    *rand.Rand
 	getSharedRand = &sync.Once{}
 )
+
+func setSharedRand() {
+	hardLocc.Lock()
+	sharedRand = lolXD.Get()
+	hardLocc.Unlock()
+}
+
+func AcquireRand() *rand.Rand {
+	return lolXD.Get()
+}
+
+func ReleaseRand(r *rand.Rand) {
+	lolXD.Put(r)
+}
 
 // RandomStrChoice returns a random item from an input slice of strings.
 func RandomStrChoice(choice []string) string {
@@ -24,50 +63,51 @@ func RandomStrChoice(choice []string) string {
 }
 
 // GetCryptoSeed returns a random int64 derived from crypto/rand.
-// This can be used as a seed for the math/rand package.
+// This can be used as a seed for various PRNGs.
 func GetCryptoSeed() int64 {
 	var seed int64
 	_ = binary.Read(crip.Reader, binary.BigEndian, &seed)
 	return seed
 }
 
-// GetOptimizedRand returns a pointer to a *new* rand.Rand which uses crypto/rand to seed a splitmix64 rng.
+// GetOptimizedRand returns a pointer to a *new* rand.Rand which uses GetCryptoSeed to seed an rng.SplitMix64.
 // Does not use the global/shared instance of a splitmix64 rng, but instead creates a new one.
 func GetOptimizedRand() *rand.Rand {
 	r := new(rng.SplitMix64)
 	r.Seed(GetCryptoSeed())
-	return rand.New(r)
+	return rand.New(r) //nolint:gosec
 }
 
 // GetSharedRand returns a pointer to our shared optimized rand.Rand which uses crypto/rand to seed a splitmix64 rng.
+// WARNING - RACY - This is not thread safe, and should only be used in a single-threaded context.
 func GetSharedRand() *rand.Rand {
 	getSharedRand.Do(func() {
-		sharedRand = GetOptimizedRand()
+		setSharedRand()
 	})
 	return sharedRand
 }
 
 // RNGUint32 returns a random uint32 using crypto/rand and splitmix64.
 func RNGUint32() uint32 {
-	getSharedRand.Do(func() {
-		sharedRand = GetOptimizedRand()
-	})
-	return sharedRand.Uint32()
+	r := lolXD.Get()
+	ui := r.Uint32()
+	lolXD.Put(r)
+	return ui
 }
 
 /*
 RNG returns integer with a maximum amount of 'n' using a global/shared instance of a splitmix64 rng.
-  - Benchmark_FastRandStr5-24            25205089      47.03 ns/op
+  - Benchmark_FastRandStr5-24          25205089      47.03 ns/op
   - Benchmark_FastRandStr25-24       	7113620     169.8  ns/op
   - Benchmark_FastRandStr55-24       	3520297     340.7  ns/op
   - Benchmark_FastRandStr500-24      	 414966    2837    ns/op
   - Benchmark_FastRandStr55555-24    	   3717  315229    ns/op
 */
 func RNG(n int) int {
-	getSharedRand.Do(func() {
-		sharedRand = GetOptimizedRand()
-	})
-	return sharedRand.Intn(n)
+	r := lolXD.Get()
+	i := r.Intn(n)
+	lolXD.Put(r)
+	return i
 }
 
 // OneInA generates a random number with a maximum of 'million' (input int).
@@ -88,22 +128,29 @@ func RandSleepMS(n int) {
 const charset = "abcdefghijklmnopqrstuvwxyz1234567890"
 const charsetWithUpper = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890"
 
+var strBufs = pool.NewStringFactory()
+
 // RandStr generates a random alphanumeric string with a max length of size.
 // Alpha charset used is a-z all lowercase.
 func RandStr(size int) string {
-	buf := make([]byte, size)
-	for i := 0; i != size; i++ {
-		buf[i] = charset[GetOptimizedRand().Uint32()%uint32(len(charset))]
-	}
-	return string(buf)
+	return randStr(charset, size)
 }
 
 // RandStrWithUpper generates a random alphanumeric string with a max length of size.
 // Alpha charset used is a-Z mixed case.
 func RandStrWithUpper(size int) string {
-	buf := make([]byte, size)
+	return randStr(charsetWithUpper, size)
+}
+
+func randStr(chars string, size int) string {
+	buf := strBufs.Get()
+	r := lolXD.Get()
 	for i := 0; i != size; i++ {
-		buf[i] = charsetWithUpper[uint32(RNG(62))%uint32(len(charsetWithUpper))]
+		ui32 := int(r.Uint32())
+		_, _ = buf.WriteRune(rune(chars[ui32%len(chars)]))
 	}
-	return string(buf)
+	lolXD.Put(r)
+	s := buf.String()
+	strBufs.MustPut(buf)
+	return s
 }

--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -40,6 +40,33 @@ func Test_RNG(t *testing.T) {
 		check(t, RNG(123454321), RNG(123454321))
 		check(t, RNGUint32(), RNGUint32())
 	}
+
+	// for coverage
+	if GetOptimizedRand().Intn(55555) == GetOptimizedRand().Intn(55555) {
+		t.Errorf("GetOptimizedRand(55555) returned the same value twice!")
+	}
+	if GetSharedRand().Intn(55555) == GetSharedRand().Intn(55555) {
+		t.Errorf("GetSharedRand(55555) returned the same value twice!")
+	}
+	r := AcquireRand()
+	one := r.Intn(55555)
+	two := r.Intn(55555)
+	if one == two {
+		t.Errorf("AcquireRand() returned the same value twice!")
+	}
+	ReleaseRand(r)
+	r = AcquireRand()
+	one1 := r.Intn(55555)
+	two1 := r.Intn(55555)
+	if one1 == two1 {
+		t.Errorf("AcquireRand() returned the same value twice!")
+	}
+	if one == one1 {
+		t.Errorf("AcquireRand()[2] returned the same value twice!")
+	}
+	if two == two1 {
+		t.Errorf("AcquireRand()[2] returned the same value twice!")
+	}
 }
 
 func Test_OneInA(t *testing.T) {
@@ -139,9 +166,9 @@ func Test_RNGUint32(t *testing.T) {
 
 func Benchmark_RandStr(b *testing.B) {
 	toTest := []int{5, 25, 55, 500, 55555}
-	for _, n := range toTest {
+	for n := range toTest {
 		for i := 1; i != 5; i++ {
-			b.Run(fmt.Sprintf("%dchar/run%d", n, i), func(b *testing.B) {
+			b.Run(fmt.Sprintf("lenSeries%d/run%d", n, i), func(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for tn := 0; tn != b.N; tn++ {

--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -160,7 +160,9 @@ func Test_RNGUint32(t *testing.T) {
 	t.Parallel()
 	// start globals fresh, just for coverage.
 	setSharedRand()
+	hardLocc.Lock()
 	getSharedRand = &sync.Once{}
+	hardLocc.Unlock()
 	RNGUint32()
 }
 

--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -1,6 +1,7 @@
 package entropy
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -136,62 +137,17 @@ func Test_RNGUint32(t *testing.T) {
 	RNGUint32()
 }
 
-func Benchmark_RandStr5(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStr(5)
-	}
-}
-
-func Benchmark_RandStr25(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStr(25)
-	}
-}
-
-func Benchmark_RandStr55(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStr(55)
-	}
-}
-
-func Benchmark_RandStr500(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStr(500)
-	}
-}
-
-func Benchmark_RandStr55555(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStr(55555)
-	}
-}
-
-func Benchmark_RandStrWithUpper5(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStrWithUpper(5)
-	}
-}
-
-func Benchmark_RandStrWithUpper25(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStrWithUpper(25)
-	}
-}
-
-func Benchmark_RandStrWithUpper55(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStrWithUpper(55)
-	}
-}
-
-func Benchmark_RandStrWithUpper500(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStrWithUpper(500)
-	}
-}
-
-func Benchmark_RandStrWithUpper55555(b *testing.B) {
-	for n := 0; n != b.N; n++ {
-		RandStrWithUpper(55555)
+func Benchmark_RandStr(b *testing.B) {
+	toTest := []int{5, 25, 55, 500, 55555}
+	for _, n := range toTest {
+		for i := 1; i != 5; i++ {
+			b.Run(fmt.Sprintf("%dchar/run%d", n, i), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for tn := 0; tn != b.N; tn++ {
+					RandStr(n)
+				}
+			})
+		}
 	}
 }

--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -8,7 +8,8 @@ import (
 
 var dupCount = 0
 
-func check[T comparable](zero T, one T, t *testing.T) {
+func check[T comparable](t *testing.T, zero T, one T) {
+	t.Helper()
 	if zero == one {
 		dupCount++
 		t.Errorf("hit a duplicate! %v == %v", zero, one)
@@ -17,11 +18,14 @@ func check[T comparable](zero T, one T, t *testing.T) {
 }
 
 func Test_RNG(t *testing.T) {
+	t.Parallel()
 	// for coverage
-	sharedRand = GetSharedRand()
+	setSharedRand()
 	RandSleepMS(5)
+	hardLocc.Lock()
 	sharedRand = nil
 	getSharedRand = &sync.Once{}
+	hardLocc.Unlock()
 	//  - - - - - -
 	if OneInA(1000000) {
 		println(string([]byte{
@@ -31,13 +35,14 @@ func Test_RNG(t *testing.T) {
 		}))
 	}
 
-	for n := 0; n != 500; n++ {
-		check(RNG(55555), RNG(55555), t)
-		check(RNGUint32(), RNGUint32(), t)
+	for n := 0; n != 55555; n++ {
+		check(t, RNG(123454321), RNG(123454321))
+		check(t, RNGUint32(), RNGUint32())
 	}
 }
 
 func Test_OneInA(t *testing.T) {
+	t.Parallel()
 	for n := 0; n < 100; n++ {
 		yes := ""
 		if OneInA(1) {
@@ -49,42 +54,48 @@ func Test_OneInA(t *testing.T) {
 	}
 }
 
-func randStrChecks(zero, one string, t *testing.T, intendedLength int) {
+func randStrChecks(t *testing.T, zero, one string, intendedLength int) {
+	t.Helper()
 	if len(zero) != len(one) {
 		t.Fatalf("RandStr output length inconsistency, len(zero) is %d but wanted len(one) which is %d", len(zero), len(one))
 	}
 	if len(zero) != intendedLength || len(one) != intendedLength {
-		t.Fatalf("RandStr output length inconsistency, len(zero) is %d and len(one) is %d, but both should have been 55", len(zero), len(one))
+		t.Fatalf(
+			"RandStr output length inconsistency, "+
+				"len(zero) is %d and len(one) is %d, but both should have been 55", len(zero), len(one))
 	}
-	check(zero, one, t)
+	check(t, zero, one)
 }
 
 func Test_RandStr(t *testing.T) {
+	t.Parallel()
 	for n := 0; n != 500; n++ {
 		zero := RandStr(55)
 		one := RandStr(55)
 		t.Logf("Random0: %s Random1: %s", zero, one)
-		randStrChecks(zero, one, t, 55)
+		randStrChecks(t, zero, one, 55)
 	}
 	t.Logf("[SUCCESS] RandStr had no collisions")
 }
 
 func Test_RandStrWithUpper(t *testing.T) {
+	t.Parallel()
 	for n := 0; n != 500; n++ {
 		zero := RandStrWithUpper(15)
 		one := RandStrWithUpper(15)
 		t.Logf("Random0: %s Random1: %s", zero, one)
-		randStrChecks(zero, one, t, 15)
+		randStrChecks(t, zero, one, 15)
 	}
 	t.Logf("[SUCCESS] RandStr had no collisions")
 }
 
 func Test_RandStr_Entropy(t *testing.T) {
+	t.Parallel()
 	var totalScore = 0
 	for n := 0; n != 500; n++ {
 		zero := RandStr(55)
 		one := RandStr(55)
-		randStrChecks(zero, one, t, 55)
+		randStrChecks(t, zero, one, 55)
 		zeroSplit := strings.Split(zero, "")
 		oneSplit := strings.Split(one, "")
 		var similarity = 0
@@ -93,10 +104,10 @@ func Test_RandStr_Entropy(t *testing.T) {
 				continue
 			}
 			similarity++
-			// t.Logf("[-] zeroSplit[%d] is the same as oneSplit[%d] (%s)", i, i, char)
 		}
 		if similarity*4 > 55 {
-			t.Errorf("[ENTROPY FAILURE] more than a quarter of the string is the same!\n zero: %s \n one: %s \nTotal similar: %d",
+			t.Errorf("[ENTROPY FAILURE] more than a quarter of the string is the same!\n "+
+				"zero: %s \n one: %s \nTotal similar: %d",
 				zero, one, similarity)
 		}
 		// t.Logf("[ENTROPY] Similarity score (lower is better): %d", similarity)
@@ -106,6 +117,7 @@ func Test_RandStr_Entropy(t *testing.T) {
 }
 
 func Test_RandomStrChoice(t *testing.T) {
+	t.Parallel()
 	if RandomStrChoice([]string{}) != "" {
 		t.Fatalf("RandomStrChoice returned a value when given an empty slice")
 	}
@@ -113,12 +125,13 @@ func Test_RandomStrChoice(t *testing.T) {
 	for n := 0; n != 500; n++ {
 		slice = append(slice, RandStr(555))
 	}
-	check(RandomStrChoice(slice), RandomStrChoice(slice), t)
+	check(t, RandomStrChoice(slice), RandomStrChoice(slice))
 }
 
 func Test_RNGUint32(t *testing.T) {
+	t.Parallel()
 	// start globals fresh, just for coverage.
-	sharedRand = GetOptimizedRand()
+	setSharedRand()
 	getSharedRand = &sync.Once{}
 	RNGUint32()
 }

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,8 @@ require (
 
 require golang.org/x/sys v0.8.0 // indirect
 
-retract v0.0.0-20220210125455-40e3d2190a52
+retract (
+	v0.0.0-20220210125455-40e3d2190a52
+	v0.9.0 // premature
+	v0.9.1 // premature (race condition)
+)


### PR DESCRIPTION
# entropy fixes and overhaul

## fix race condition

splitmix64 has a race condition. it likely (usually) doesn't matter all that much, essentially skeeto references a pointer to the instance of splitmix64 directly during the PRNG's regular churn.
in terms of the random values this seems fine, but i missed it because i wasn't using `t.Parrallel()`. Downstream packages compiled with the race detector of course threw traces.

the fix involves implementing a `sync.Pool` of splitmix64 pointers without breaking the existing API. it doesn't seem to slow things down, in fact if anything it seems to speed up operations and reduce allocations (go figure).

## performance

besides the above prng pool, the random string generators have been overhauled, and their performance has *_dramatically_* increased in all areas.

look at this shit;

### before

```
goos: linux
goarch: amd64
pkg: git.tcp.direct/kayos/common/entropy
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
Benchmark_RandStr/5char/run1-32         	 991692	     1164 ns/op	    336 B/op	     17 allocs/op
Benchmark_RandStr/5char/run2-32         	1000000	     1146 ns/op	    336 B/op	     17 allocs/op
Benchmark_RandStr/5char/run3-32         	1000000	     1147 ns/op	    336 B/op	     17 allocs/op
Benchmark_RandStr/5char/run4-32         	 990246	     1146 ns/op	    336 B/op	     17 allocs/op
Benchmark_RandStr/25char/run1-32        	 209188	     5661 ns/op	   1664 B/op	     77 allocs/op
Benchmark_RandStr/25char/run2-32        	 209958	     5661 ns/op	   1664 B/op	     77 allocs/op
Benchmark_RandStr/25char/run3-32        	 209828	     5743 ns/op	   1664 B/op	     77 allocs/op
Benchmark_RandStr/25char/run4-32        	 209623	     5655 ns/op	   1664 B/op	     77 allocs/op
Benchmark_RandStr/55char/run1-32        	  96064	    12418 ns/op	   3648 B/op	    167 allocs/op
Benchmark_RandStr/55char/run2-32        	  95988	    12428 ns/op	   3648 B/op	    167 allocs/op
Benchmark_RandStr/55char/run3-32        	  96433	    12423 ns/op	   3648 B/op	    167 allocs/op
Benchmark_RandStr/55char/run4-32        	  95943	    12418 ns/op	   3648 B/op	    167 allocs/op
Benchmark_RandStr/500char/run1-32       	  10000	   112782 ns/op	  33024 B/op	   1502 allocs/op
Benchmark_RandStr/500char/run2-32       	  10000	   114732 ns/op	  33024 B/op	   1502 allocs/op
Benchmark_RandStr/500char/run3-32       	  10000	   112755 ns/op	  33024 B/op	   1502 allocs/op
Benchmark_RandStr/500char/run4-32       	  10000	   112990 ns/op	  33024 B/op	   1502 allocs/op
Benchmark_RandStr/55555char/run1-32     	     92	 12508040 ns/op	3670224 B/op	 166667 allocs/op
Benchmark_RandStr/55555char/run2-32     	     92	 12507297 ns/op	3670222 B/op	 166667 allocs/op
Benchmark_RandStr/55555char/run3-32     	     93	 12517544 ns/op	3670226 B/op	 166667 allocs/op
Benchmark_RandStr/55555char/run4-32     	     92	 12514224 ns/op	3670222 B/op	 166667 allocs/op
PASS
ok  	git.tcp.direct/kayos/common/entropy	24.257s
```


### after


```
goos: linux
goarch: amd64
pkg: git.tcp.direct/kayos/common/entropy
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
Benchmark_RandStr/5char/run1-32         	  	24768908	       	48.37 ns/op	        21 B/op	      2 allocs/op
Benchmark_RandStr/5char/run2-32         	  	24689665	       	49.21 ns/op	        21 B/op	      2 allocs/op
Benchmark_RandStr/5char/run3-32         	  	24731571	      	48.09 ns/op	        21 B/op	      2 allocs/op
Benchmark_RandStr/5char/run4-32           		24766143	       	48.16 ns/op	        21 B/op	      2 allocs/op
Benchmark_RandStr/25char/run1-32        	  	11914915	  	99.61 ns/op	        48 B/op	      2 allocs/op
Benchmark_RandStr/25char/run2-32          		11995597	       	99.82 ns/op	        48 B/op	      2 allocs/op
Benchmark_RandStr/25char/run3-32          		11996383	  	99.66 ns/op	        48 B/op	      2 allocs/op
Benchmark_RandStr/25char/run4-32        	  	11901414	        102.3 ns/op	        48 B/op	      2 allocs/op
Benchmark_RandStr/55char/run1-32        	  	6582032  	       	182.4 ns/op	        80 B/op	      2 allocs/op
Benchmark_RandStr/55char/run2-32        	  	6563631	        	182.4 ns/op	        80 B/op	      2 allocs/op
Benchmark_RandStr/55char/run3-32        	  	6564248  		182.3 ns/op	        80 B/op	      2 allocs/op
Benchmark_RandStr/55char/run4-32        	  	6571722	   	   	181.9 ns/op	        80 B/op	      2 allocs/op
Benchmark_RandStr/500char/run1-32       	   	878709	   	    	 1297 ns/op	       529 B/op       2 allocs/op
Benchmark_RandStr/500char/run2-32       	   	878859	  	       	 1295 ns/op	       529 B/op	      2 allocs/op
Benchmark_RandStr/500char/run3-32       	   	879234	  	       	 1325 ns/op	       529 B/op	      2 allocs/op
Benchmark_RandStr/500char/run4-32       	   	883886	  	       	 1296 ns/op	       529 B/op	      2 allocs/op
Benchmark_RandStr/55555char/run1-32     	     	8374	  	       137120 ns/op	     57493 B/op       2 allocs/op
Benchmark_RandStr/55555char/run2-32     	     	8313	  	       137030 ns/op	     57493 B/op       2 allocs/op
Benchmark_RandStr/55555char/run3-32     	     	8277	  	       137153 ns/op	     57493 B/op       2 allocs/op
Benchmark_RandStr/55555char/run4-32     	     	8287	  	       136919 ns/op	     57509 B/op       2 allocs/op
PASS
ok  	git.tcp.direct/kayos/common/entropy	25.016s
```
